### PR TITLE
Setup minimal structure for using ReactJS with Flask.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# JavaScript
+node_modules/
+package-lock.json

--- a/CodeWord/__init__.py
+++ b/CodeWord/__init__.py
@@ -3,7 +3,7 @@ from flask import Flask, render_template
 app = Flask(__name__)
 
 # CodeWord accepts only GET requests, and returns only a single web page and
-# its TypeScript to play the game.
+# its JavaScript dependenies to play the game.
 @app.route('/')
 def index():
     return render_template('index.html')

--- a/CodeWord/static/css/theme.css
+++ b/CodeWord/static/css/theme.css
@@ -101,3 +101,7 @@ header {
 .btn-group button:hover {
   background-color: DarkGray;
 }
+
+#reactTest {
+  color: White;
+}

--- a/CodeWord/static/js/HelloReact.js
+++ b/CodeWord/static/js/HelloReact.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const HelloReact = () => {
+    return (
+        <h3>Hello, React</h3>
+    );
+};
+
+export default HelloReact;

--- a/CodeWord/static/js/index.js
+++ b/CodeWord/static/js/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import HelloReact from './HelloReact';
+
+render(<HelloReact />, document.getElementById('reactTest'));

--- a/CodeWord/templates/index.html
+++ b/CodeWord/templates/index.html
@@ -3,13 +3,9 @@
     <title>CodeWord</title>
     <!-- CSS -->
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/theme.css') }}">
-    {% block css %}{% endblock %}
     <!-- JavaScript -->
-    <script type=text/javascript">
-        $SCRIPT_ROOT = {{ request.script_root|tojson|safe }};
-    </script>
     <script type=text/javascript src="{{ url_for('static', filename='js/test.js') }}"></script>
-    {% block scripts %}{% endblock %}
+    <script defer src="{{ url_for('static', filename='dist/bundle.js') }}"></script></head>
   </head>
   <body>
     <!-- Application header. -->
@@ -106,5 +102,6 @@
         </div>
       </div>
     </div>
+    <div id="reactTest"></div>
   </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Code is free to use, but please provide proper credit.
 ### Prerequisites
 1. Python 2.7 or Python 3.5+
 2. virtualenv
+3. npm
 
 ### Quickstart
 1. Create a python virtual environment (I prefer `virtualenvwrapper`):
@@ -24,7 +25,12 @@ $ workon codeword
 $ pip install -r requirements.txt
 ```
 
-3. Run development server from project root:
+3. Install JavaScript modules
+```
+$ npm install
+```
+
+4. Run development server from project root:
 ```
 $ flask run
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "codeword",
+  "version": "1.0.0",
+  "description": "Number/word game inspired by Wordle",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --mode=development --open --hot",
+    "build": "webpack --mode=development"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jdn5126/CodeWord.git"
+  },
+  "author": "Jeffrey D Nelson",
+  "license": "GPL-3.0-or-later",
+  "bugs": {
+    "url": "https://github.com/jdn5126/CodeWord/issues"
+  },
+  "homepage": "https://github.com/jdn5126/CodeWord#readme",
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.17.5",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-react": "^7.16.7",
+    "babel-loader": "^8.2.3",
+    "css-loader": "^6.6.0",
+    "html-webpack-plugin": "^5.5.0",
+    "style-loader": "^3.3.1",
+    "webpack": "^5.69.1",
+    "webpack-cli": "^4.9.2",
+    "webpack-dev-server": "^4.7.4"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ]
+  },
+  "proxy": "http://localhost:5000"
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const HtmlWebPackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: path.resolve(__dirname, "./CodeWord/static/js/"),
+  output: {
+    path: path.resolve(__dirname, 'CodeWord/static/dist'),
+    filename: 'bundle.js',
+  },
+  resolve: {
+    modules: [path.join(__dirname, 'CodeWord/static/js'), 'node_modules'],
+    alias: {
+      react: path.join(__dirname, 'node_modules', 'react'),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: 'style-loader',
+          },
+          {
+            loader: 'css-loader',
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebPackPlugin({
+      template: './CodeWord/templates/index.html',
+    }),
+  ],
+};
+


### PR DESCRIPTION
The purpose of this pull-request is to add the minimal structure necessary for using ReactJS to handle most (or all) frontend logic. Though I am using `webpack` to bundle the React JS files into `CodeWord/static/dist/bundle.js` and `CodeWord/static/dist/index.html`, I am still having Flask render `CodeWord/templates/index.html` as the entry point. I am not sure if this is the right thing to do, but it seems correct to me now, as I want to test with `flask run` rather than `webpack-dev-server`. To me, that seems closer to what the actual deployment will be.